### PR TITLE
Precompute present features

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Extract the fixed features:
 
 Run the original attack:
 
-    $ go run src/attacks/knn.orig/knn.orig.go
+    $ go run src/attack/knn.orig/knn.orig.go
     2016/04/12 11:32:49 loaded instances: main
     2016/04/12 11:32:50 loaded instances: training
     2016/04/12 11:32:52 loaded instances: testing
@@ -47,7 +47,7 @@ Run the original attack:
 
 Run the fixed attack:
 
-    $ go run src/attacks/knn.fixed/knn.fixed.go 
+    $ go run src/attack/knn.fixed/knn.fixed.go 
     2016/04/12 11:32:45 loaded instances: main
     2016/04/12 11:32:46 loaded instances: training
     2016/04/12 11:32:46 loaded instances: testing

--- a/attack/knn.fixed/knn.fixed.go
+++ b/attack/knn.fixed/knn.fixed.go
@@ -208,7 +208,7 @@ func determineWeights(feat [][]float64, weight []float64, start, end int) {
 
 	for i := 0; i < FeatNum; i++ {
 		if weight[i] > 0 {
-			weight[i] *= 0.9 + rand.float64()*0.2
+			weight[i] *= 0.9 + rand.Float64()*0.2
 		}
 	}
 


### PR DESCRIPTION
For each training point, record the indices of the features that were defined
for that point. Pass these values as a slice to the distance function, so that
it only tries to compute distances between the training point and all other
points in the testing set for features defined in the training point.

While we still have to test that features are defined for each of the other
points in the testing set, we save significant computation by not having to test
for every single distance computation whether the feature is defined for the
point being trained on.
